### PR TITLE
Document upload feature.

### DIFF
--- a/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchiving.xcdatamodeld/XMPPMessageArchiving.xcdatamodel/contents
+++ b/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchiving.xcdatamodeld/XMPPMessageArchiving.xcdatamodel/contents
@@ -14,6 +14,7 @@
         <attribute name="bareJidStr" attributeType="String" indexed="YES" syncable="YES"/>
         <attribute name="body" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="composing" attributeType="Boolean" defaultValueString="NO" indexed="YES" syncable="YES"/>
+        <attribute name="documentId" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
         <attribute name="localTimestamp" attributeType="Date" indexed="YES" syncable="YES"/>
         <attribute name="message" optional="YES" transient="YES" syncable="YES"/>
         <attribute name="messageId" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
@@ -23,10 +24,11 @@
         <attribute name="remoteTimestamp" optional="YES" attributeType="Date" indexed="YES" syncable="YES"/>
         <attribute name="streamBareJidStr" attributeType="String" indexed="YES" syncable="YES"/>
         <attribute name="thread" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="uploadDownloadTaskId" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
         <attribute name="userString" optional="YES" attributeType="String" syncable="YES"/>
     </entity>
     <elements>
         <element name="XMPPMessageArchiving_Contact_CoreDataObject" positionX="-182" positionY="198" width="128" height="148"/>
-        <element name="XMPPMessageArchiving_Message_CoreDataObject" positionX="160" positionY="192" width="128" height="255"/>
+        <element name="XMPPMessageArchiving_Message_CoreDataObject" positionX="160" positionY="192" width="128" height="285"/>
     </elements>
 </model>

--- a/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchiving_Message_CoreDataObject.h
+++ b/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchiving_Message_CoreDataObject.h
@@ -7,6 +7,11 @@ typedef NS_ENUM(int16_t, XMPPMessageArchiving_Message_CoreDataObjectMessageStatu
     XMPPMessageArchiving_Message_CoreDataObjectMessageStatusSent    = 1,
     XMPPMessageArchiving_Message_CoreDataObjectMessageStatusReceived = 2,
     XMPPMessageArchiving_Message_CoreDataObjectMessageStatusFailed = 3,
+    
+    XMPPMessageArchiving_Message_CoreDataObjectMessageStatusUploading = 4,
+    XMPPMessageArchiving_Message_CoreDataObjectMessageStatusToDownload = 5,
+    XMPPMessageArchiving_Message_CoreDataObjectMessageStatusDownloading = 6,
+    XMPPMessageArchiving_Message_CoreDataObjectMessageStatusDownloaded = 7,
 };
 
 @interface XMPPMessageArchiving_Message_CoreDataObject : NSManagedObject
@@ -40,6 +45,9 @@ typedef NS_ENUM(int16_t, XMPPMessageArchiving_Message_CoreDataObjectMessageStatu
 
 @property (strong, nonatomic) NSString *messageId;
 @property (assign, nonatomic) XMPPMessageArchiving_Message_CoreDataObjectMessageStatus messageStatus;
+
+@property (strong, nonatomic) NSString *documentId; // Attachment in messages
+@property (strong, nonatomic) NSString *uploadDownloadTaskId; // Attachment upload/download task
 
 @property (strong, nonatomic) NSString *userString;
 

--- a/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchiving_Message_CoreDataObject.m
+++ b/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchiving_Message_CoreDataObject.m
@@ -26,6 +26,8 @@
 @dynamic streamBareJidStr;
 @dynamic messageStatus;
 @dynamic messageId;
+@dynamic documentId;
+@dynamic uploadDownloadTaskId;
 @dynamic userString;
 
 #pragma mark Transient message

--- a/Extensions/ZyncroTech/XMPPMessage+ZyncroDocument.h
+++ b/Extensions/ZyncroTech/XMPPMessage+ZyncroDocument.h
@@ -1,0 +1,19 @@
+//
+//  XMPPMessage+ZyncroDocument.h
+//  ZyncroMessenger
+//
+//  Created by Luis Valdés on 4/3/15.
+//  Copyright (c) 2015 Zyncro Tech. All rights reserved.
+//
+
+#import <XMPPFramework/XMPPMessage.h>
+
+@interface XMPPMessage (ZyncroDocument)
+
+- (void)addDocumentId:(NSString *)documentId;
+
+- (NSString *)documentId;
+
+- (BOOL)hasDocumentId;
+
+@end

--- a/Extensions/ZyncroTech/XMPPMessage+ZyncroDocument.m
+++ b/Extensions/ZyncroTech/XMPPMessage+ZyncroDocument.m
@@ -1,0 +1,48 @@
+//
+//  XMPPMessage+ZyncroDocument.m
+//  ZyncroMessenger
+//
+//  Created by Luis Valdés on 4/3/15.
+//  Copyright (c) 2015 Zyncro Tech. All rights reserved.
+//
+
+#import "XMPPMessage+ZyncroDocument.h"
+#import "NSXMLElement+XMPP.h"
+
+static NSString *const ZMNameDocument           = @"document";
+static NSString *const ZMAttributeDocument      = @"id";
+static NSString *const ZMXMLNSZyncroMessenger   = @"http://www.zyncro.com/messenger";
+
+@implementation XMPPMessage (ZyncroDocument)
+
+- (void)addDocumentId:(NSString *)documentId {
+    if (!documentId || documentId.length == 0) {
+        return;
+    }
+    /**
+     * <message>
+     *      ...
+     *      <body> __ZLink__ </body>
+     *      ...
+     *      <document xmlns="http://www.zyncro.com/messenger" id="__documentUrn__" />
+     *      ...
+     * </message>
+     */
+    NSXMLElement *document = [NSXMLElement elementWithName:ZMNameDocument xmlns:ZMXMLNSZyncroMessenger];
+    [document addAttributeWithName:ZMAttributeDocument stringValue:documentId];
+    
+    [self addChild:document];
+}
+
+- (NSString *)documentId {
+    NSXMLElement *document  = [self elementForName:ZMNameDocument xmlns:ZMXMLNSZyncroMessenger];
+    NSString *documentId    = [document attributeStringValueForName:ZMAttributeDocument];
+    return documentId;
+}
+
+- (BOOL)hasDocumentId {
+    NSString *documentId = [self documentId];
+    return (documentId && documentId.length > 0);
+}
+
+@end

--- a/XMPPFramework.podspec.json
+++ b/XMPPFramework.podspec.json
@@ -506,6 +506,16 @@
         ]
       },
       "prefix_header_contents": "#define HAVE_XMPP_SUBSPEC_XEP_0335"
+    },
+    {
+      "name": "ZyncroTech",
+      "source_files": "Extensions/ZyncroTech/**/*.{h,m}",
+      "dependencies": {
+        "XMPPFramework/Core": [
+
+        ]
+      },
+      "prefix_header_contents": "#define HAVE_XMPP_SUBSPEC_ZYNCROTECH"
     }
   ]
 }


### PR DESCRIPTION
Add XMPPMessage ZyncroDocument extension to include a DocumentID in a message.
Add documentId & uploadDownloadTaskId to Message CoreData Entity to track upload/download progress for a specific document.
Add ZyncroTech subspec to podspec to include new files to implement Zyncro's business cases.
